### PR TITLE
add: overload zip

### DIFF
--- a/utils/src/main/java/jp/util/functional/TriFunction.java
+++ b/utils/src/main/java/jp/util/functional/TriFunction.java
@@ -1,0 +1,16 @@
+package jp.util.functional;
+
+
+import java.util.Objects;
+import java.util.function.Function;
+
+@FunctionalInterface
+public interface TriFunction<S, T, U, R> {
+
+    R apply(S s, T t, U u);
+
+    default <V> TriFunction<S, T, U, V> andThen(Function<? super R, ? extends V> after) {
+        Objects.requireNonNull(after);
+        return (S s, T t, U u) -> after.apply(apply(s, t, u));
+    }
+}

--- a/utils/src/main/java/jp/util/iteration/IterationSupport.java
+++ b/utils/src/main/java/jp/util/iteration/IterationSupport.java
@@ -5,6 +5,9 @@ import jp.util.functional.Pair;
 import jp.util.functional.Triple;
 
 import java.util.Iterator;
+import java.util.Spliterators;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 public class IterationSupport {
 
@@ -74,12 +77,17 @@ public class IterationSupport {
     }
 
     public static <L, R> Iterable<Pair<L, R>> zip(Iterable<L> ls, Iterable<R> rs) {
-        return () -> new Iterator<Pair<L, R>>() {
+        return () -> zip(ls.iterator(), rs.iterator());
+    }
 
-            Iterator<L> lit = ls.iterator();
+    // 受け取ったストリームは一旦閉じるので注意。
+    public static <L, R> Stream<Pair<L, R>> zip(Stream<L> ls, Stream<R> rs) {
+        return StreamSupport.stream(
+                Spliterators.spliteratorUnknownSize(zip(ls.iterator(), rs.iterator()), 0), false);
+    }
 
-            Iterator<R> rit = rs.iterator();
-
+    public static <L, R> Iterator<Pair<L, R>> zip(Iterator<L> lit, Iterator<R> rit) {
+        return new Iterator<Pair<L, R>>() {
             @Override
             public boolean hasNext() {
                 return lit.hasNext() && rit.hasNext();
@@ -93,13 +101,17 @@ public class IterationSupport {
     }
 
     public static <L, M, R> Iterable<Triple<L, M, R>> zip(Iterable<L> ls, Iterable<M> ms, Iterable<R> rs) {
-        return () -> new Iterator<Triple<L, M, R>>() {
+        return () -> zip(ls.iterator(), ms.iterator(), rs.iterator());
+    }
 
-            Iterator<L> lit = ls.iterator();
+    // 受け取ったストリームは一旦閉じるので注意。
+    public static <L, M, R> Stream<Triple<L, M, R>> zip(Stream<L> ls, Stream<M> ms, Stream<R> rs) {
+        return StreamSupport.stream(
+                Spliterators.spliteratorUnknownSize(zip(ls.iterator(), ms.iterator(), rs.iterator()), 0), false);
+    }
 
-            Iterator<M> mit = ms.iterator();
-
-            Iterator<R> rit = rs.iterator();
+    public static <L, M, R> Iterator<Triple<L, M, R>> zip(Iterator<L> lit, Iterator<M> mit, Iterator<R> rit) {
+        return new Iterator<Triple<L, M, R>>() {
 
             @Override
             public boolean hasNext() {

--- a/utils/src/main/java/jp/util/iteration/IterationSupport.java
+++ b/utils/src/main/java/jp/util/iteration/IterationSupport.java
@@ -2,10 +2,12 @@ package jp.util.iteration;
 
 
 import jp.util.functional.Pair;
+import jp.util.functional.TriFunction;
 import jp.util.functional.Triple;
 
 import java.util.Iterator;
 import java.util.Spliterators;
+import java.util.function.BiFunction;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
@@ -80,22 +82,39 @@ public class IterationSupport {
         return () -> zip(ls.iterator(), rs.iterator());
     }
 
+
+    public static <L, R, T> Iterable<T> zip(Iterable<L> ls, Iterable<R> rs, BiFunction<? super L, ? super R, ? extends T> merger) {
+        return () -> zip(ls.iterator(), rs.iterator(), merger);
+    }
+
     // 受け取ったストリームは一旦閉じるので注意。
     public static <L, R> Stream<Pair<L, R>> zip(Stream<L> ls, Stream<R> rs) {
         return StreamSupport.stream(
                 Spliterators.spliteratorUnknownSize(zip(ls.iterator(), rs.iterator()), 0), false);
     }
 
+    // 受け取ったストリームは一旦閉じるので注意。
+    public static <L, R, T> Stream<T> zip(Stream<L> ls, Stream<R> rs, BiFunction<? super L, ? super R, ? extends T> merger) {
+        return StreamSupport.stream(
+                Spliterators.spliteratorUnknownSize(zip(ls.iterator(), rs.iterator(), merger), 0), false);
+    }
+
+
     public static <L, R> Iterator<Pair<L, R>> zip(Iterator<L> lit, Iterator<R> rit) {
-        return new Iterator<Pair<L, R>>() {
+        return zip(lit, rit, Pair::of);
+    }
+
+
+    public static <L, R, T> Iterator<T> zip(Iterator<L> lit, Iterator<R> rit, BiFunction<? super L, ? super R, ? extends T> merger) {
+        return new Iterator<T>() {
             @Override
             public boolean hasNext() {
                 return lit.hasNext() && rit.hasNext();
             }
 
             @Override
-            public Pair<L, R> next() {
-                return Pair.of(lit.next(), rit.next());
+            public T next() {
+                return merger.apply(lit.next(), rit.next());
             }
         };
     }
@@ -104,14 +123,28 @@ public class IterationSupport {
         return () -> zip(ls.iterator(), ms.iterator(), rs.iterator());
     }
 
+    public static <L, M, R, T> Iterable<T> zip(Iterable<L> ls, Iterable<M> ms, Iterable<R> rs, TriFunction<L, M, R, T> merger) {
+        return () -> zip(ls.iterator(), ms.iterator(), rs.iterator(), merger);
+    }
+
     // 受け取ったストリームは一旦閉じるので注意。
     public static <L, M, R> Stream<Triple<L, M, R>> zip(Stream<L> ls, Stream<M> ms, Stream<R> rs) {
         return StreamSupport.stream(
                 Spliterators.spliteratorUnknownSize(zip(ls.iterator(), ms.iterator(), rs.iterator()), 0), false);
     }
 
+    // 受け取ったストリームは一旦閉じるので注意。
+    public static <L, M, R, T> Stream<T> zip(Stream<L> ls, Stream<M> ms, Stream<R> rs, TriFunction<L, M, R, T> merger) {
+        return StreamSupport.stream(
+                Spliterators.spliteratorUnknownSize(zip(ls.iterator(), ms.iterator(), rs.iterator(), merger), 0), false);
+    }
+
     public static <L, M, R> Iterator<Triple<L, M, R>> zip(Iterator<L> lit, Iterator<M> mit, Iterator<R> rit) {
-        return new Iterator<Triple<L, M, R>>() {
+        return zip(lit, mit, rit, Triple::of);
+    }
+
+    public static <L, M, R, T> Iterator<T> zip(Iterator<L> lit, Iterator<M> mit, Iterator<R> rit, TriFunction<L, M, R, T> merger) {
+        return new Iterator<T>() {
 
             @Override
             public boolean hasNext() {
@@ -119,8 +152,8 @@ public class IterationSupport {
             }
 
             @Override
-            public Triple<L, M, R> next() {
-                return Triple.of(lit.next(), mit.next(), rit.next());
+            public T next() {
+                return merger.apply(lit.next(), mit.next(), rit.next());
             }
         };
     }

--- a/utils/src/test/java/jp/util/iteration/IteratorSupportTest.java
+++ b/utils/src/test/java/jp/util/iteration/IteratorSupportTest.java
@@ -7,6 +7,7 @@ import org.junit.Test;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -99,4 +100,44 @@ public class IteratorSupportTest {
             assertFalse(it.hasNext());
         }
     }
+
+    @Test
+    public void test_zipWIthMerger() {
+        List<Integer> ls = Arrays.asList(1, 2, 3, 4, 5);
+        List<String> rs = Arrays.asList("hoge", "foo", "bar");
+        List<Boolean> ms = Arrays.asList(true, false, false, false, true);
+        {
+            Iterator<String> it = IterationSupport.zip(ls, rs,
+                    (a, b) -> String.join("|", Objects.toString(a), Objects.toString(b))).iterator();
+            assertEquals("1|hoge", it.next());
+            assertEquals("2|foo", it.next());
+            assertEquals("3|bar", it.next());
+            assertFalse(it.hasNext());
+        }
+        {
+            Iterator<String> it = IterationSupport.zip(ls, ms, rs,
+                    (a, b, c) -> String.join("|", Objects.toString(a), Objects.toString(b), Objects.toString(c))).iterator();
+            assertEquals("1|true|hoge", it.next());
+            assertEquals("2|false|foo", it.next());
+            assertEquals("3|false|bar", it.next());
+            assertFalse(it.hasNext());
+        }
+        {
+            Iterator<String> it = IterationSupport.zip(ls.stream(), rs.stream(),
+                    (a, b) -> String.join("|", Objects.toString(a), Objects.toString(b))).iterator();
+            assertEquals("1|hoge", it.next());
+            assertEquals("2|foo", it.next());
+            assertEquals("3|bar", it.next());
+            assertFalse(it.hasNext());
+        }
+        {
+            Iterator<String> it = IterationSupport.zip(ls.stream(), ms.stream(), rs.stream(),
+                    (a, b, c) -> String.join("|", Objects.toString(a), Objects.toString(b), Objects.toString(c))).iterator();
+            assertEquals("1|true|hoge", it.next());
+            assertEquals("2|false|foo", it.next());
+            assertEquals("3|false|bar", it.next());
+            assertFalse(it.hasNext());
+        }
+    }
+
 }

--- a/utils/src/test/java/jp/util/iteration/IteratorSupportTest.java
+++ b/utils/src/test/java/jp/util/iteration/IteratorSupportTest.java
@@ -67,9 +67,10 @@ public class IteratorSupportTest {
 
     @Test
     public void test_zip() {
+        List<Integer> ls = Arrays.asList(1, 2, 3, 4, 5);
+        List<String> rs = Arrays.asList("hoge", "foo", "bar");
+        List<Boolean> ms = Arrays.asList(true, false, false, false, true);
         {
-            List<Integer> ls = Arrays.asList(1, 2, 3, 4, 5);
-            List<String> rs = Arrays.asList("hoge", "foo", "bar");
             Iterator<Pair<Integer, String>> it = IterationSupport.zip(ls, rs).iterator();
             assertEquals(Pair.of(1, "hoge"), it.next());
             assertEquals(Pair.of(2, "foo"), it.next());
@@ -77,10 +78,21 @@ public class IteratorSupportTest {
             assertFalse(it.hasNext());
         }
         {
-            List<Integer> ls = Arrays.asList(1, 2, 3, 4, 5);
-            List<Boolean> ms = Arrays.asList(true, false, false, false, true);
-            List<String> rs = Arrays.asList("hoge", "foo", "bar");
             Iterator<Triple<Integer, Boolean, String>> it = IterationSupport.zip(ls, ms, rs).iterator();
+            assertEquals(Triple.of(1, true, "hoge"), it.next());
+            assertEquals(Triple.of(2, false, "foo"), it.next());
+            assertEquals(Triple.of(3, false, "bar"), it.next());
+            assertFalse(it.hasNext());
+        }
+        {
+            Iterator<Pair<Integer, String>> it = IterationSupport.zip(ls.stream(), rs.stream()).iterator();
+            assertEquals(Pair.of(1, "hoge"), it.next());
+            assertEquals(Pair.of(2, "foo"), it.next());
+            assertEquals(Pair.of(3, "bar"), it.next());
+            assertFalse(it.hasNext());
+        }
+        {
+            Iterator<Triple<Integer, Boolean, String>> it = IterationSupport.zip(ls.stream(), ms.stream(), rs.stream()).iterator();
             assertEquals(Triple.of(1, true, "hoge"), it.next());
             assertEquals(Triple.of(2, false, "foo"), it.next());
             assertEquals(Triple.of(3, false, "bar"), it.next());


### PR DESCRIPTION
思いつきですが、
`Iterator`を受け取って`Iterator`を返す `zip`と `Stream`を受け取って`Stream`を返す`zip`を作ってみました。
他のメソッドみたいに、`Iterable`を受け取らないタイプのものは、極力`Iterable`を返してあげるのが便利かと思いましたが、
`Iterable`を受け取るタイプのものは `Iterator`で受け取ったり`Stream`で受け取ったりするとよしなな気がしたので。