### PR TITLE
feature: unzip

### DIFF
--- a/utils/src/main/java/jp/util/iteration/IterationSupport.java
+++ b/utils/src/main/java/jp/util/iteration/IterationSupport.java
@@ -162,6 +162,88 @@ public class IterationSupport {
         };
     }
 
+    public static <L, R> Pair<Iterable<L>, Iterable<R>> unzip2(Iterable<Pair<L, R>> xs) {
+        Iterable<L> ls = () -> new Iterator<L>() {
+
+            Iterator<Pair<L, R>> it = xs.iterator();
+
+            @Override
+            public boolean hasNext() {
+                return it.hasNext();
+            }
+
+            @Override
+            public L next() {
+                return it.next().getLeft();
+            }
+        };
+
+        Iterable<R> rs = () -> new Iterator<R>() {
+
+            Iterator<Pair<L, R>> it = xs.iterator();
+
+            @Override
+            public boolean hasNext() {
+                return it.hasNext();
+            }
+
+            @Override
+            public R next() {
+                return it.next().getRight();
+            }
+        };
+        return Pair.of(ls, rs);
+    }
+
+    public static <L, M, R> Triple<Iterable<L>, Iterable<M>, Iterable<R>> unzip3(Iterable<Triple<L, M, R>> xs) {
+        Iterable<L> ls = () -> new Iterator<L>() {
+
+            Iterator<Triple<L, M, R>> it = xs.iterator();
+
+            @Override
+            public boolean hasNext() {
+                return it.hasNext();
+            }
+
+            @Override
+            public L next() {
+                return it.next().getLeft();
+            }
+        };
+
+        Iterable<M> ms = () -> new Iterator<M>() {
+
+            Iterator<Triple<L, M, R>> it = xs.iterator();
+
+            @Override
+            public boolean hasNext() {
+                return it.hasNext();
+            }
+
+            @Override
+            public M next() {
+                return it.next().getMiddle();
+            }
+        };
+
+        Iterable<R> rs = () -> new Iterator<R>() {
+
+            Iterator<Triple<L, M, R>> it = xs.iterator();
+
+            @Override
+            public boolean hasNext() {
+                return it.hasNext();
+            }
+
+            @Override
+            public R next() {
+                return it.next().getRight();
+            }
+        };
+
+        return Triple.of(ls, ms, rs);
+    }
+
     public static <L, R> Iterable<Pair<L, R>> product(Iterable<L> ls, Iterable<R> rs) {
         if (!ls.iterator().hasNext() || !rs.iterator().hasNext())
             return IterationSupport::emptyIterator;

--- a/utils/src/test/java/jp/util/iteration/IteratorSupportTest.java
+++ b/utils/src/test/java/jp/util/iteration/IteratorSupportTest.java
@@ -194,6 +194,71 @@ public class IteratorSupportTest {
     }
 
     @Test
+    public void test_unzip2() {
+        List<Pair<Integer, String>> pairs = Arrays.asList(
+                Pair.of(1, "hoge"),
+                Pair.of(2, "foo"),
+                Pair.of(3, "bar")
+        );
+        {
+            Pair<Iterable<Integer>, Iterable<String>> unzip2 = IterationSupport.unzip2(pairs);
+            Iterator<Integer> lit = unzip2.getLeft().iterator();
+            assertNext(1, lit);
+            assertNext(2, lit);
+            assertNext(3, lit);
+            assertNextFailed(lit);
+            Iterator<String> rit = unzip2.getRight().iterator();
+            assertNext("hoge", rit);
+            assertNext("foo", rit);
+            assertNext("bar", rit);
+            assertNextFailed(rit);
+        }
+        {
+            Pair<Iterable<Integer>, Iterable<String>> unzip = IterationSupport.unzip2(new ArrayList<>());
+            Iterator<Integer> lit = unzip.getLeft().iterator();
+            assertNextFailed(lit);
+            Iterator<String> rit = unzip.getRight().iterator();
+            assertNextFailed(rit);
+        }
+    }
+
+    @Test
+    public void test_unzip3() {
+        List<Triple<Integer, Boolean, String>> triples = Arrays.asList(
+                Triple.of(1, true, "hoge"),
+                Triple.of(2, true, "foo"),
+                Triple.of(3, false, "bar")
+        );
+        {
+            Triple<Iterable<Integer>, Iterable<Boolean>, Iterable<String>> unzip3 = IterationSupport.unzip3(triples);
+            Iterator<Integer> lit = unzip3.getLeft().iterator();
+            assertNext(1, lit);
+            assertNext(2, lit);
+            assertNext(3, lit);
+            assertNextFailed(lit);
+            Iterator<Boolean> mit = unzip3.getMiddle().iterator();
+            assertNext(true, mit);
+            assertNext(true, mit);
+            assertNext(false, mit);
+            assertNextFailed(mit);
+            Iterator<String> rit = unzip3.getRight().iterator();
+            assertNext("hoge", rit);
+            assertNext("foo", rit);
+            assertNext("bar", rit);
+            assertNextFailed(rit);
+        }
+        {
+            Triple<Iterable<Integer>, Iterable<Boolean>, Iterable<String>> unzip3 = IterationSupport.unzip3(new ArrayList<>());
+            Iterator<Integer> lit = unzip3.getLeft().iterator();
+            assertNextFailed(lit);
+            Iterator<Boolean> mit = unzip3.getMiddle().iterator();
+            assertNextFailed(mit);
+            Iterator<String> rit = unzip3.getRight().iterator();
+            assertNextFailed(rit);
+        }
+    }
+
+    @Test
     public void test_product() {
         List<Integer> ls = Arrays.asList(1, 2);
         List<String> rs = Arrays.asList("hoge", "foo", "bar");


### PR DESCRIPTION
zipの逆の操作をするunzipを実装しました。
メソッド名をオーバーロードできなかったので、`unzip2`と`unzip3`にしました。
`zip`とか`product`も後々`zip2`とか`product2`とかに平仄合わせるかも。
それでいうと、`Pair`, `Triple`も`Tuple2`, `Tuple3`に変える？